### PR TITLE
Projects: make partner organisation optional

### DIFF
--- a/config.njk
+++ b/config.njk
@@ -191,6 +191,7 @@ collections:
       - label: "Partner Organisation (For Handed Over projects)"
         name: "partner"
         widget: "string"
+        required: false
       - label: "Phase"
         name: "phase"
         widget: "select"


### PR DESCRIPTION
Partner organisations is a required field currently, only needed for handed over projects