### PR TITLE
Add category and sub category to prompts

### DIFF
--- a/config.njk
+++ b/config.njk
@@ -475,7 +475,11 @@ collections:
       - label: "Category"
         name: "category"
         widget: "select"
-        options: ["General productivity", "Teaching and learning", "Design and user research", "Project management", "Writing and communicating"]
+        options: ["Find information", "Create and review content", "Triage and route", "Analyse Information", "Run meetings and appointments", "Build data foundations", "Learning and development"]
+      - label: "Subcategory"
+        name: "subcategory"
+        widget: "string"
+        required: false
       - label: "Tags"
         name: "tags"
         widget: "string"


### PR DESCRIPTION
Add category and sub category to prompts

Have checked and it is ok to update live content before release with these categories

Leaving sub category as an open string for now, can make select when we sure up the options

<img width="747" height="210" alt="Screenshot 2025-11-14 at 15 18 34" src="https://github.com/user-attachments/assets/a6e9f77f-6151-46a8-a599-4e08ae29a623" />
