### PR TITLE
Add content field to prompts

### DIFF
--- a/config.njk
+++ b/config.njk
@@ -475,7 +475,7 @@ collections:
       - label: "Category"
         name: "category"
         widget: "select"
-        options: ["Find information", "Create and review content", "Triage and route information", "Analyse Information", "Run meetings and appointments", "Build data foundations", "Learning and development"]
+        options: ["Find information", "Create and review content", "Triage and route information", "Analyse information", "Run meetings and appointments", "Build data foundations", "Learning and development"]
       - label: "Subcategory"
         name: "subcategory"
         widget: "string"

--- a/config.njk
+++ b/config.njk
@@ -475,7 +475,7 @@ collections:
       - label: "Category"
         name: "category"
         widget: "select"
-        options: ["Find information", "Create and review content", "Triage and route", "Analyse Information", "Run meetings and appointments", "Build data foundations", "Learning and development"]
+        options: ["Find information", "Create and review content", "Triage and route information", "Analyse Information", "Run meetings and appointments", "Build data foundations", "Learning and development"]
       - label: "Subcategory"
         name: "subcategory"
         widget: "string"
@@ -489,12 +489,12 @@ collections:
         widget: "boolean"
         default: true
         required: false
-      - label: "What this prompt does"
+      - label: "What this prompt does: To be removed after Knowledge Hub is live"
         name: "use"
         widget: "markdown"
         required: false
-      - label: "Before you start"
-        name: "beforeYouStart"
+      - label: "Content"
+        name: "content"
         widget: "markdown"
         required: false
       - label: "Prompt"


### PR DESCRIPTION
Adding content field to the prompts - reusing the before you start field as it hasn't been filled in yet
Keeping the what this prompt does field until after launch

Updating the categories to fit with content update

<img width="846" height="1167" alt="Screenshot 2025-11-18 at 10 27 26" src="https://github.com/user-attachments/assets/f9d434a6-e457-477f-8640-37de49485773" />
