### PR TITLE
Upgrade to latest version of Decap

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -7,7 +7,7 @@
     <title>Content Manager</title>
   </head>
   <body>
-    <script src="https://unpkg.com/decap-cms@3.7.2/dist/decap-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@3.9.0/dist/decap-cms.js"></script>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/showdown/2.1.0/showdown.min.js"
       integrity="sha512-LhccdVNGe2QMEfI3x4DVV3ckMRe36TfydKss6mJpdHjNFiV07dFpS2xzeZedptKZrwxfICJpez09iNioiSZ3hA=="


### PR DESCRIPTION
We were fixed at v3.7.2 for some time, but a bug has now been fixed meaning we can upgrade to v3.9.0

https://github.com/decaporg/decap-cms/issues/7575

