### PR TITLE
Change directory to functions

### DIFF
--- a/config.njk
+++ b/config.njk
@@ -530,34 +530,24 @@ collections:
     create: true
     slug: "{{title}}"
     fields: 
-      - label: "Use case name"
-        name: "useCaseName"
+      - label: "Sub function name"
+        name: "subFunctionName"
         widget: "string"
       - label: "Sponsor"
         name: "sponsor"
-        widget: "string"
-        required: false
-      - label: "Lead department"
-        name: "leadDepartment"
         widget: "string"
         required: false
       - label: "Function"
         name: "function"
         widget: "string"
         required: false
-      - label: "What it does"
-        name: "whatItDoes"
+      - label: "Use cases"
+        name: "useCases"
         widget: "string"
         required: false
-      - label: "remarks"
-        name: "remarks"
-        widget: "string"
-        required: false
-      - label: "Verified"
-        name: "verified"
-        widget: "boolean"
-        default: true
-        required: false
+        hint: "Use a comma to separate multiple tags"
+
+  
 
   - label: "Pages"
     name: "Pages"


### PR DESCRIPTION
We're removing the directory as is and changing it to be a list of sub functions and their sponsors

<img width="953" height="705" alt="Screenshot 2025-11-19 at 17 10 48" src="https://github.com/user-attachments/assets/74054a03-37c5-4a02-aba0-393b85b612a1" />
