### PR TITLE
Add note for publishing data on Knowledge Hub

### DIFF
--- a/_data/envs.js
+++ b/_data/envs.js
@@ -3,4 +3,5 @@ require("dotenv").config();
 module.exports = {
   runMode: process.env.ELEVENTY_RUN_MODE,
   buildHook: process.env.BUILD_HOOK,
+  cmsContentRepoToken: process.env.CMS_CONTENT_REPO_TOKEN,
 };

--- a/index.njk
+++ b/index.njk
@@ -288,6 +288,87 @@
         }
       });
 
+      CMS.registerEventListener({
+        name: 'postPublish',
+        handler: async ({ entry }) => {
+          const collection = entry.get('collection');
+          
+          if (!collection.includes('knowledge_hub')) {
+            return;
+          }
+
+          const slug = entry.get('slug');
+          
+          const repo = 'i-dot-ai/ai-gov-uk-cms-content';
+          const branch = `cms/${collection}/${slug}`;
+          let prUrl = '';
+
+          try {
+            const response = await fetch(`https://api.github.com/repos/${repo}/pulls?head=i-dot-ai:${branch}&state=closed`, {
+              headers: {
+                Authorization: `token {{ envs.cmsContentRepoToken }}`,
+                "X-GitHub-Api-Version": "2022-11-28",
+              },
+            });
+            const data = await response.json();
+
+            if (data.length === 0) {
+              throw new Error('No pull request found');
+            }
+
+            prUrl = data[0].html_url;
+          } catch (error) {
+            console.error('error', error);
+          }
+
+          if (!prUrl) {
+            return;
+          }
+
+          const addCommentToPRDialog = document.createElement('div');
+          addCommentToPRDialog.innerHTML = `
+            <div 
+              role="alertdialog"
+              aria-modal="true"
+              aria-labelledby="add-comment-to-pr-dialog-title"
+              style="
+                position: fixed;
+                top: 8px;
+                right: 72px;
+                color: #000;
+                padding: 16px 20px;
+                background: #fff;
+                border-radius: 8px;
+                box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+                font-family: sans-serif;
+                font-size: 14px;
+                z-index: 1000;
+                display: flex;
+                align-items: center;
+                gap: 12px;
+              "
+            >
+              <p id="add-comment-to-pr-dialog-title" style="margin: 0;">📝 Want to leave a publish note? Leave a comment on the PR.</p>
+              <a href="${prUrl}" target="_blank" style="
+                color: #000;
+                font-weight: bold;
+                text-decoration: underline;
+              ">View PR</a>
+              <span id="cms-banner-close" aria-label="Close" style="cursor:pointer;">✕</span>
+            </div>
+          `;
+
+          document.body.appendChild(addCommentToPRDialog);
+
+          navigation.addEventListener('navigate', (event) => {
+            addCommentToPRDialog.remove();
+          });
+          addCommentToPRDialog.querySelector('#cms-banner-close').addEventListener('click', () => {
+            addCommentToPRDialog.remove();
+          });
+        }
+      });
+
     </script>
 
     {# Old comments


### PR DESCRIPTION
# add note for publishing data on Knowledge Hub

<img width="1724" height="464" alt="Screenshot 2026-03-11 at 13 16 05" src="https://github.com/user-attachments/assets/c72c5601-8f42-4fac-be94-c04d3e83dd4c" />


## Context

Content writers have requested the ability to put comments on when items are published in order to have a record of when and why content has been changed

## Implementation

This approach uses the Github functionality which decap is built on.

## Usage

When Knowledge Hub content is published, a dialog is presented on the page with a link to the just merged PR in order to edit the description directly on that PR